### PR TITLE
Use fswatcher for OIDC TLS server

### DIFF
--- a/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
+++ b/charts/dapr/charts/dapr_sentry/templates/dapr_sentry_deployment.yaml
@@ -213,6 +213,7 @@ spec:
 {{- end }}
 {{- if .Values.oidc.enabled }}
         - "--oidc-enabled=true"
+        - "--oidc-server-listen-address=0.0.0.0"
 {{- if .Values.oidc.jwksURI }}
         - "--oidc-jwks-uri={{ .Values.oidc.jwksURI }}"
 {{- end }}

--- a/cmd/sentry/options/options.go
+++ b/cmd/sentry/options/options.go
@@ -136,7 +136,7 @@ func New(origArgs []string) *Options {
 	fs.DurationVar(&opts.JWT.TTL, "jwt-ttl", config.DefaultJWTTTL, "Time-to-live for JWT tokens (default 24h)")
 	fs.BoolVar(&opts.OIDC.Enabled, "oidc-enabled", false, "Enable OIDC HTTP server for Dapr Sentry")
 	fs.IntVar(&opts.OIDC.ServerListenPort, "oidc-server-listen-port", 9080, "The port for the OIDC HTTP server")
-	fs.StringVar(&opts.OIDC.ServerListenAddress, "oidc-server-listen-address", "0.0.0.0", "The address for the OIDC HTTP server")
+	fs.StringVar(&opts.OIDC.ServerListenAddress, "oidc-server-listen-address", "localhost", "The address for the OIDC HTTP server")
 	fs.BoolVar(&opts.OIDC.TLSEnabled, "oidc-server-tls-enabled", true, "Serve OIDC HTTP with TLS")
 	fs.StringVar(&opts.OIDC.tlsCertFile, "oidc-server-tls-cert-file", "", "TLS certificate file for the OIDC HTTP server (required when OIDC HTTP server is enabled)")
 	fs.StringVar(&opts.OIDC.tlsKeyFile, "oidc-server-tls-key-file", "", "TLS key file for the OIDC HTTP server (required when OIDC HTTP server is enabled)")

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -16,7 +16,6 @@ package sentry
 import (
 	"context"
 	"crypto"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -53,13 +52,14 @@ type Options struct {
 }
 
 type OIDCOptions struct {
-	Enabled             bool        // Enable OIDC HTTP endpoints
-	ServerListenAddress string      // Address for OIDC HTTP server
-	ServerListenPort    int         // Port for OIDC HTTP endpoints
-	TLSConfig           *tls.Config // custom TLS configuration for the HTTP server (Optional)
-	Domains             []string    // Domains that public endpoints can be accessed from (Optional)
-	JWKSURI             *string     // Force the public JWKS URI to this value (Optional)
-	PathPrefix          *string     // Path prefix for HTTP endpoints (Optional)
+	Enabled             bool     // Enable OIDC HTTP endpoints
+	ServerListenAddress string   // Address for OIDC HTTP server
+	ServerListenPort    int      // Port for OIDC HTTP endpoints
+	Domains             []string // Domains that public endpoints can be accessed from (Optional)
+	JWKSURI             *string  // Force the public JWKS URI to this value (Optional)
+	PathPrefix          *string  // Path prefix for HTTP endpoints (Optional)
+	TLSCertPath         *string
+	TLSKeyPath          *string
 }
 
 // CertificateAuthority is the interface for the Sentry Certificate Authority.
@@ -193,7 +193,8 @@ func newOIDCServerRunner(opts Options, camngr ca.Signer) (concurrency.Runner, er
 		JWTIssuer:          &issuer,
 		Healthz:            opts.Healthz,
 		AllowedHosts:       opts.OIDC.Domains,
-		TLSConfig:          opts.OIDC.TLSConfig,
+		TLSCertPath:        opts.OIDC.TLSCertPath,
+		TLSKeyPath:         opts.OIDC.TLSKeyPath,
 		SignatureAlgorithm: signAlg,
 	}
 

--- a/tests/integration/suite/sentry/oidc/custom.go
+++ b/tests/integration/suite/sentry/oidc/custom.go
@@ -293,9 +293,10 @@ func (o *customOIDCServer) testInsecureHTTPMode(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
-	go func() {
-		httpSentry.Run(t, ctx)
-	}()
+	httpSentry.Run(t, ctx)
+	t.Cleanup(func() {
+		httpSentry.Cleanup(t)
+	})
 
 	httpSentry.WaitUntilRunning(t, ctx)
 


### PR DESCRIPTION
Rely on the top level Sentry fswatcher to restart the OIDC server when the TLS certificate/key files change.

Wait for those files to be available before starting the server in TLS serving mode.

Change the sentry OIDC server default listen address to localhost. Hard code `0.0.0.0` listen address in Kubernetes.